### PR TITLE
Fixed interpolateData function

### DIFF
--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -235,11 +235,8 @@ namespace KMC_Lattice {
 
 	double interpolateData(const std::vector<std::pair<double, double>>& data, const double x_val) {
 		for (int i = 1; i < (int)data.size(); i++) {
-			if (data[i - 1].first < x_val && data[i].first > x_val) {
+			if (data[i - 1].first <= x_val && data[i].first >= x_val) {
 				return data[i - 1].second + ((data[i].second - data[i - 1].second) / (data[i].first - data[i - 1].first))*(x_val - data[i - 1].first);
-			}
-			if (abs(data[i].first - x_val) < 1e-6) {
-				return data[i].second;
 			}
 		}
 		cout << "Warning! The input x-value lies outside the range of the input data set." << endl;

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -707,6 +707,12 @@ namespace UtilsTests {
 			data_vec[i].second = exp(-data_vec[i].first / 2.85);
 		}
 		EXPECT_NEAR(1 / exp(1), interpolateData(data_vec, 2.85), 1e-4);
+		// Test with a small lifetime and nonlinear x-vals
+		for (int i = 0; i < (int)data_vec.size(); i++) {
+			data_vec[i].first = pow(10, log10(1e-12) + i * 0.1);
+			data_vec[i].second = exp(-data_vec[i].first / 1e-10);
+		}
+		EXPECT_NEAR(1 / exp(1), interpolateData(data_vec, 1e-10), 1e-4);
 		for (int i = 0; i < (int)data_vec.size(); i++) {
 			data_vec[i].first = 0.2*i;
 			data_vec[i].second = 2.5*data_vec[i].first - 5.0;


### PR DESCRIPTION
Utils:
-updated interpolateData function to remove x-val equality check which can cause issues with log-spaced x-val data with small magnitudes

Resolves #40 