### PR TITLE
chooseNextEvent Bugfix

### DIFF
--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -68,7 +68,7 @@ namespace KMC_Lattice {
 
 	list<Event*>::const_iterator Simulation::chooseNextEvent() {
 		return min_element(event_ptrs.begin(), event_ptrs.end(), [](Event* a, Event* b) {
-			return (a != nullptr && b != nullptr) && (a->getExecutionTime() < b->getExecutionTime());
+			return (a != nullptr && b == nullptr) || ((a != nullptr && b != nullptr) && (a->getExecutionTime() < b->getExecutionTime()));
 		});
 	}
 


### PR DESCRIPTION
-Resolves #44 

Simulation class:
-upated chooseNextEvent function by adding a comparison case to the min_element lambda comparison function that correctly indicates that any valid event pointer is less than a nullptr, so that chooseNextEvent always chooses a real event ptr over a nullptr if possible