### PR TITLE
removeObject Bugfix

### DIFF
--- a/src/Simulation.cpp
+++ b/src/Simulation.cpp
@@ -233,7 +233,7 @@ namespace KMC_Lattice {
 			// Clear occupancy of site
 			lattice.clearOccupancy(object_ptr->getCoords());
 			// Delete the corresponding Event pointer
-			removeEvent(*object_ptr->getEventIt());
+			event_ptrs.erase(object_ptr->getEventIt());
 			// Delete the Object pointer
 			object_ptrs.erase(it);
 		}


### PR DESCRIPTION
-Resolves #45 

Simulation class:
-updated removeObject function to remove the corresponding event_ptr by accessing it through the getEventIt function instead of the removeEvent function, thereby guaranteeing the correct event_ptr is removed even when it is a nullptr and saving time that was spent searching through the event_ptrs list to find the matching event ptr